### PR TITLE
Test max tail call in Linux

### DIFF
--- a/bpf/CMakeLists.txt
+++ b/bpf/CMakeLists.txt
@@ -23,6 +23,7 @@ set(test_cases
     "rolling_lru"
     "tail_call"
     "xdp"
+    "max_tail_call"
     )
 
 function(process_test_cases worker)

--- a/bpf/max_tail_call.c
+++ b/bpf/max_tail_call.c
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "bpf.h"
+
+// Test to check the maximum tail call callee count, without the caller.
+
+// Define a macro that defines a program which tail calls a function for the bind hook.
+#define DEFINE_BIND_TAIL_FUNC(x)                                                                \
+    SEC("bind/" #x)                                                                             \
+    bind_action_t BindMonitor_Test_Callee##x(bind_md_t* ctx)                                    \
+    {                                                                                           \
+        int i = x + 1;                                                                          \
+        bpf_printk("BindMonitor_Test_Callee: Tail call index [cur = %d], [next = %i]\n", x, i); \
+        if (bpf_tail_call(ctx, &bind_tail_call_map, i) < 0) {                                   \
+            bpf_printk("Tail call failed at index %d\n", i);                                    \
+        }                                                                                       \
+        return BIND_DENY;                                                                       \
+    }
+
+#define DECLARE_BIND_TAIL_FUNC(x) bind_action_t BindMonitor_Test_Callee##x(bind_md_t* ctx);
+
+DECLARE_BIND_TAIL_FUNC(0)
+DECLARE_BIND_TAIL_FUNC(1)
+DECLARE_BIND_TAIL_FUNC(2)
+DECLARE_BIND_TAIL_FUNC(3)
+DECLARE_BIND_TAIL_FUNC(4)
+DECLARE_BIND_TAIL_FUNC(5)
+DECLARE_BIND_TAIL_FUNC(6)
+DECLARE_BIND_TAIL_FUNC(7)
+DECLARE_BIND_TAIL_FUNC(8)
+DECLARE_BIND_TAIL_FUNC(9)
+DECLARE_BIND_TAIL_FUNC(10)
+DECLARE_BIND_TAIL_FUNC(11)
+DECLARE_BIND_TAIL_FUNC(12)
+DECLARE_BIND_TAIL_FUNC(13)
+DECLARE_BIND_TAIL_FUNC(14)
+DECLARE_BIND_TAIL_FUNC(15)
+DECLARE_BIND_TAIL_FUNC(16)
+DECLARE_BIND_TAIL_FUNC(17)
+DECLARE_BIND_TAIL_FUNC(18)
+DECLARE_BIND_TAIL_FUNC(19)
+DECLARE_BIND_TAIL_FUNC(20)
+DECLARE_BIND_TAIL_FUNC(21)
+DECLARE_BIND_TAIL_FUNC(22)
+DECLARE_BIND_TAIL_FUNC(23)
+DECLARE_BIND_TAIL_FUNC(24)
+DECLARE_BIND_TAIL_FUNC(25)
+DECLARE_BIND_TAIL_FUNC(26)
+DECLARE_BIND_TAIL_FUNC(27)
+DECLARE_BIND_TAIL_FUNC(28)
+DECLARE_BIND_TAIL_FUNC(29)
+DECLARE_BIND_TAIL_FUNC(30)
+DECLARE_BIND_TAIL_FUNC(31)
+DECLARE_BIND_TAIL_FUNC(32)
+DECLARE_BIND_TAIL_FUNC(33)
+DECLARE_BIND_TAIL_FUNC(34)
+
+// Number of tail calls is 35, without the caller.
+struct
+{
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __type(key, uint32_t);
+    __uint(max_entries, MAX_TAIL_CALL_CNT + 3);
+    __array(values, bind_action_t(bind_md_t* ctx));
+} bind_tail_call_map SEC(".maps") = {
+    .values = {
+        BindMonitor_Test_Callee0,  BindMonitor_Test_Callee1,  BindMonitor_Test_Callee2,  BindMonitor_Test_Callee3,
+        BindMonitor_Test_Callee4,  BindMonitor_Test_Callee5,  BindMonitor_Test_Callee6,  BindMonitor_Test_Callee7,
+        BindMonitor_Test_Callee8,  BindMonitor_Test_Callee9,  BindMonitor_Test_Callee10, BindMonitor_Test_Callee11,
+        BindMonitor_Test_Callee12, BindMonitor_Test_Callee13, BindMonitor_Test_Callee14, BindMonitor_Test_Callee15,
+        BindMonitor_Test_Callee16, BindMonitor_Test_Callee17, BindMonitor_Test_Callee18, BindMonitor_Test_Callee19,
+        BindMonitor_Test_Callee20, BindMonitor_Test_Callee21, BindMonitor_Test_Callee22, BindMonitor_Test_Callee23,
+        BindMonitor_Test_Callee24, BindMonitor_Test_Callee25, BindMonitor_Test_Callee26, BindMonitor_Test_Callee27,
+        BindMonitor_Test_Callee28, BindMonitor_Test_Callee29, BindMonitor_Test_Callee30, BindMonitor_Test_Callee31,
+        BindMonitor_Test_Callee32, BindMonitor_Test_Callee33, BindMonitor_Test_Callee34,
+
+    }};
+
+DEFINE_BIND_TAIL_FUNC(0)
+DEFINE_BIND_TAIL_FUNC(1)
+DEFINE_BIND_TAIL_FUNC(2)
+DEFINE_BIND_TAIL_FUNC(3)
+DEFINE_BIND_TAIL_FUNC(4)
+DEFINE_BIND_TAIL_FUNC(5)
+DEFINE_BIND_TAIL_FUNC(6)
+DEFINE_BIND_TAIL_FUNC(7)
+DEFINE_BIND_TAIL_FUNC(8)
+DEFINE_BIND_TAIL_FUNC(9)
+DEFINE_BIND_TAIL_FUNC(10)
+DEFINE_BIND_TAIL_FUNC(11)
+DEFINE_BIND_TAIL_FUNC(12)
+DEFINE_BIND_TAIL_FUNC(13)
+DEFINE_BIND_TAIL_FUNC(14)
+DEFINE_BIND_TAIL_FUNC(15)
+DEFINE_BIND_TAIL_FUNC(16)
+DEFINE_BIND_TAIL_FUNC(17)
+DEFINE_BIND_TAIL_FUNC(18)
+DEFINE_BIND_TAIL_FUNC(19)
+DEFINE_BIND_TAIL_FUNC(20)
+DEFINE_BIND_TAIL_FUNC(21)
+DEFINE_BIND_TAIL_FUNC(22)
+DEFINE_BIND_TAIL_FUNC(23)
+DEFINE_BIND_TAIL_FUNC(24)
+DEFINE_BIND_TAIL_FUNC(25)
+DEFINE_BIND_TAIL_FUNC(26)
+DEFINE_BIND_TAIL_FUNC(27)
+DEFINE_BIND_TAIL_FUNC(28)
+DEFINE_BIND_TAIL_FUNC(29)
+DEFINE_BIND_TAIL_FUNC(30)
+DEFINE_BIND_TAIL_FUNC(31)
+DEFINE_BIND_TAIL_FUNC(32)
+DEFINE_BIND_TAIL_FUNC(33)
+
+bind_hook_t BindMonitor_Test_Caller;
+
+SEC("bind")
+bind_action_t
+BindMonitor_Test_Caller(bind_md_t* ctx)
+{
+    bpf_printk("BindMonitor_Test_Caller: Start Tail call\n");
+    if (bpf_tail_call(ctx, &bind_tail_call_map, 0) < 0) {
+        bpf_printk("Failed Tail call index %d\n", 0);
+        return BIND_DENY;
+    }
+
+    return BIND_DENY;
+}
+
+SEC("bind/34")
+bind_action_t
+BindMonitor_Test_Callee34(bind_md_t* ctx)
+{
+    bpf_printk("Last Tail call index: BindMonitor_Test_Callee34\n");
+    // This function is the last tail call function for the bind hook.
+    // This function returns BIND_PERMIT to allow the bind request to proceed.
+    return BIND_PERMIT;
+}

--- a/bpf/max_tail_call.c
+++ b/bpf/max_tail_call.c
@@ -14,9 +14,9 @@
     {                                                                                   \
         int i = x + 1;                                                                  \
         bpf_printk("xdp_test_callee: Tail call index [cur = %d], [next = %i]\n", x, i); \
-        if (bpf_tail_call(ctx, &xdp_tail_call_map, i) < 0) {                            \
+        bpf_tail_call(ctx, &xdp_tail_call_map, i);                                      \
             bpf_printk("Tail call failed at index %d\n", i);                            \
-        }                                                                               \
+                                                                                        \
         return -1;                                                                      \
     }
 
@@ -62,7 +62,7 @@ DECLARE_XDP_TAIL_FUNC(34)
 struct
 {
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-    __type(key, sizeof(__u32));
+    __uint(key_size, sizeof(__u32));
     __uint(max_entries, MAX_TAIL_CALL_COUNT + 3);
     __array(values, int(struct xdp_md* ctx));
 } xdp_tail_call_map SEC(".maps") = {
@@ -118,11 +118,8 @@ int
 xdp_test_caller(struct xdp_md* ctx)
 {
     bpf_printk("xdp_test_caller: Starting Tail callees with [MAX COUNT = %d]\n", MAX_TAIL_CALL_COUNT);
-    if (bpf_tail_call(ctx, &xdp_tail_call_map, 0) < 0) {
-        bpf_printk("Failed Tail call index %d\n", 0);
-        return -1;
-    }
-
+    bpf_tail_call(ctx, &xdp_tail_call_map, 0);
+    bpf_printk("Failed Tail call index %d\n", 0);
     return -1;
 }
 
@@ -135,3 +132,5 @@ xdp_test_callee34(struct xdp_md* ctx)
     // This function returns 0 to allow the xdp request to proceed.
     return 0;
 }
+
+char _license[] SEC("license") = "GPL/MIT";

--- a/bpf/max_tail_call.c
+++ b/bpf/max_tail_call.c
@@ -62,7 +62,7 @@ DECLARE_XDP_TAIL_FUNC(34)
 struct
 {
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-    __type(key, uint32_t);
+    __type(key, sizeof(__u32));
     __uint(max_entries, MAX_TAIL_CALL_COUNT + 3);
     __array(values, int(struct xdp_md* ctx));
 } xdp_tail_call_map SEC(".maps") = {

--- a/bpf/max_tail_call.c
+++ b/bpf/max_tail_call.c
@@ -7,56 +7,56 @@
 
 #define MAX_TAIL_CALL_COUNT 32
 
-// Define a macro that defines a program which tail calls a function for the bind hook.
-#define DEFINE_BIND_TAIL_FUNC(x)                                                                \
-    SEC("bind/" #x)                                                                             \
-    bind_action_t BindMonitor_Test_Callee##x(bind_md_t* ctx)                                    \
-    {                                                                                           \
-        int i = x + 1;                                                                          \
-        bpf_printk("BindMonitor_Test_Callee: Tail call index [cur = %d], [next = %i]\n", x, i); \
-        if (bpf_tail_call(ctx, &bind_tail_call_map, i) < 0) {                                   \
-            bpf_printk("Tail call failed at index %d\n", i);                                    \
-        }                                                                                       \
-        return BIND_DENY;                                                                       \
+// Define a macro that defines a program which tail calls a function for the xdp hook.
+#define DEFINE_XDP_TAIL_FUNC(x)                                                         \
+    SEC("xdp/" #x)                                                                      \
+    int xdp_test_callee##x(struct xdp_md* ctx)                                          \
+    {                                                                                   \
+        int i = x + 1;                                                                  \
+        bpf_printk("xdp_test_callee: Tail call index [cur = %d], [next = %i]\n", x, i); \
+        if (bpf_tail_call(ctx, &xdp_tail_call_map, i) < 0) {                            \
+            bpf_printk("Tail call failed at index %d\n", i);                            \
+        }                                                                               \
+        return -1;                                                                      \
     }
 
-#define DECLARE_BIND_TAIL_FUNC(x) bind_action_t BindMonitor_Test_Callee##x(bind_md_t* ctx);
+#define DECLARE_XDP_TAIL_FUNC(x) int xdp_test_callee##x(struct xdp_md* ctx);
 
-DECLARE_BIND_TAIL_FUNC(0)
-DECLARE_BIND_TAIL_FUNC(1)
-DECLARE_BIND_TAIL_FUNC(2)
-DECLARE_BIND_TAIL_FUNC(3)
-DECLARE_BIND_TAIL_FUNC(4)
-DECLARE_BIND_TAIL_FUNC(5)
-DECLARE_BIND_TAIL_FUNC(6)
-DECLARE_BIND_TAIL_FUNC(7)
-DECLARE_BIND_TAIL_FUNC(8)
-DECLARE_BIND_TAIL_FUNC(9)
-DECLARE_BIND_TAIL_FUNC(10)
-DECLARE_BIND_TAIL_FUNC(11)
-DECLARE_BIND_TAIL_FUNC(12)
-DECLARE_BIND_TAIL_FUNC(13)
-DECLARE_BIND_TAIL_FUNC(14)
-DECLARE_BIND_TAIL_FUNC(15)
-DECLARE_BIND_TAIL_FUNC(16)
-DECLARE_BIND_TAIL_FUNC(17)
-DECLARE_BIND_TAIL_FUNC(18)
-DECLARE_BIND_TAIL_FUNC(19)
-DECLARE_BIND_TAIL_FUNC(20)
-DECLARE_BIND_TAIL_FUNC(21)
-DECLARE_BIND_TAIL_FUNC(22)
-DECLARE_BIND_TAIL_FUNC(23)
-DECLARE_BIND_TAIL_FUNC(24)
-DECLARE_BIND_TAIL_FUNC(25)
-DECLARE_BIND_TAIL_FUNC(26)
-DECLARE_BIND_TAIL_FUNC(27)
-DECLARE_BIND_TAIL_FUNC(28)
-DECLARE_BIND_TAIL_FUNC(29)
-DECLARE_BIND_TAIL_FUNC(30)
-DECLARE_BIND_TAIL_FUNC(31)
-DECLARE_BIND_TAIL_FUNC(32)
-DECLARE_BIND_TAIL_FUNC(33)
-DECLARE_BIND_TAIL_FUNC(34)
+DECLARE_XDP_TAIL_FUNC(0)
+DECLARE_XDP_TAIL_FUNC(1)
+DECLARE_XDP_TAIL_FUNC(2)
+DECLARE_XDP_TAIL_FUNC(3)
+DECLARE_XDP_TAIL_FUNC(4)
+DECLARE_XDP_TAIL_FUNC(5)
+DECLARE_XDP_TAIL_FUNC(6)
+DECLARE_XDP_TAIL_FUNC(7)
+DECLARE_XDP_TAIL_FUNC(8)
+DECLARE_XDP_TAIL_FUNC(9)
+DECLARE_XDP_TAIL_FUNC(10)
+DECLARE_XDP_TAIL_FUNC(11)
+DECLARE_XDP_TAIL_FUNC(12)
+DECLARE_XDP_TAIL_FUNC(13)
+DECLARE_XDP_TAIL_FUNC(14)
+DECLARE_XDP_TAIL_FUNC(15)
+DECLARE_XDP_TAIL_FUNC(16)
+DECLARE_XDP_TAIL_FUNC(17)
+DECLARE_XDP_TAIL_FUNC(18)
+DECLARE_XDP_TAIL_FUNC(19)
+DECLARE_XDP_TAIL_FUNC(20)
+DECLARE_XDP_TAIL_FUNC(21)
+DECLARE_XDP_TAIL_FUNC(22)
+DECLARE_XDP_TAIL_FUNC(23)
+DECLARE_XDP_TAIL_FUNC(24)
+DECLARE_XDP_TAIL_FUNC(25)
+DECLARE_XDP_TAIL_FUNC(26)
+DECLARE_XDP_TAIL_FUNC(27)
+DECLARE_XDP_TAIL_FUNC(28)
+DECLARE_XDP_TAIL_FUNC(29)
+DECLARE_XDP_TAIL_FUNC(30)
+DECLARE_XDP_TAIL_FUNC(31)
+DECLARE_XDP_TAIL_FUNC(32)
+DECLARE_XDP_TAIL_FUNC(33)
+DECLARE_XDP_TAIL_FUNC(34)
 
 // Number of tail calls is 35, without the caller.
 struct
@@ -64,77 +64,74 @@ struct
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
     __type(key, uint32_t);
     __uint(max_entries, MAX_TAIL_CALL_COUNT + 3);
-    __array(values, bind_action_t(bind_md_t* ctx));
-} bind_tail_call_map SEC(".maps") = {
+    __array(values, int(struct xdp_md* ctx));
+} xdp_tail_call_map SEC(".maps") = {
     .values = {
-        BindMonitor_Test_Callee0,  BindMonitor_Test_Callee1,  BindMonitor_Test_Callee2,  BindMonitor_Test_Callee3,
-        BindMonitor_Test_Callee4,  BindMonitor_Test_Callee5,  BindMonitor_Test_Callee6,  BindMonitor_Test_Callee7,
-        BindMonitor_Test_Callee8,  BindMonitor_Test_Callee9,  BindMonitor_Test_Callee10, BindMonitor_Test_Callee11,
-        BindMonitor_Test_Callee12, BindMonitor_Test_Callee13, BindMonitor_Test_Callee14, BindMonitor_Test_Callee15,
-        BindMonitor_Test_Callee16, BindMonitor_Test_Callee17, BindMonitor_Test_Callee18, BindMonitor_Test_Callee19,
-        BindMonitor_Test_Callee20, BindMonitor_Test_Callee21, BindMonitor_Test_Callee22, BindMonitor_Test_Callee23,
-        BindMonitor_Test_Callee24, BindMonitor_Test_Callee25, BindMonitor_Test_Callee26, BindMonitor_Test_Callee27,
-        BindMonitor_Test_Callee28, BindMonitor_Test_Callee29, BindMonitor_Test_Callee30, BindMonitor_Test_Callee31,
-        BindMonitor_Test_Callee32, BindMonitor_Test_Callee33, BindMonitor_Test_Callee34,
-
+        xdp_test_callee0,  xdp_test_callee1,  xdp_test_callee2,  xdp_test_callee3,
+        xdp_test_callee4,  xdp_test_callee5,  xdp_test_callee6,  xdp_test_callee7,
+        xdp_test_callee8,  xdp_test_callee9,  xdp_test_callee10, xdp_test_callee11,
+        xdp_test_callee12, xdp_test_callee13, xdp_test_callee14, xdp_test_callee15,
+        xdp_test_callee16, xdp_test_callee17, xdp_test_callee18, xdp_test_callee19,
+        xdp_test_callee20, xdp_test_callee21, xdp_test_callee22, xdp_test_callee23,
+        xdp_test_callee24, xdp_test_callee25, xdp_test_callee26, xdp_test_callee27,
+        xdp_test_callee28, xdp_test_callee29, xdp_test_callee30, xdp_test_callee31,
+        xdp_test_callee32, xdp_test_callee33, xdp_test_callee34,
     }};
 
-DEFINE_BIND_TAIL_FUNC(0)
-DEFINE_BIND_TAIL_FUNC(1)
-DEFINE_BIND_TAIL_FUNC(2)
-DEFINE_BIND_TAIL_FUNC(3)
-DEFINE_BIND_TAIL_FUNC(4)
-DEFINE_BIND_TAIL_FUNC(5)
-DEFINE_BIND_TAIL_FUNC(6)
-DEFINE_BIND_TAIL_FUNC(7)
-DEFINE_BIND_TAIL_FUNC(8)
-DEFINE_BIND_TAIL_FUNC(9)
-DEFINE_BIND_TAIL_FUNC(10)
-DEFINE_BIND_TAIL_FUNC(11)
-DEFINE_BIND_TAIL_FUNC(12)
-DEFINE_BIND_TAIL_FUNC(13)
-DEFINE_BIND_TAIL_FUNC(14)
-DEFINE_BIND_TAIL_FUNC(15)
-DEFINE_BIND_TAIL_FUNC(16)
-DEFINE_BIND_TAIL_FUNC(17)
-DEFINE_BIND_TAIL_FUNC(18)
-DEFINE_BIND_TAIL_FUNC(19)
-DEFINE_BIND_TAIL_FUNC(20)
-DEFINE_BIND_TAIL_FUNC(21)
-DEFINE_BIND_TAIL_FUNC(22)
-DEFINE_BIND_TAIL_FUNC(23)
-DEFINE_BIND_TAIL_FUNC(24)
-DEFINE_BIND_TAIL_FUNC(25)
-DEFINE_BIND_TAIL_FUNC(26)
-DEFINE_BIND_TAIL_FUNC(27)
-DEFINE_BIND_TAIL_FUNC(28)
-DEFINE_BIND_TAIL_FUNC(29)
-DEFINE_BIND_TAIL_FUNC(30)
-DEFINE_BIND_TAIL_FUNC(31)
-DEFINE_BIND_TAIL_FUNC(32)
-DEFINE_BIND_TAIL_FUNC(33)
+DEFINE_XDP_TAIL_FUNC(0)
+DEFINE_XDP_TAIL_FUNC(1)
+DEFINE_XDP_TAIL_FUNC(2)
+DEFINE_XDP_TAIL_FUNC(3)
+DEFINE_XDP_TAIL_FUNC(4)
+DEFINE_XDP_TAIL_FUNC(5)
+DEFINE_XDP_TAIL_FUNC(6)
+DEFINE_XDP_TAIL_FUNC(7)
+DEFINE_XDP_TAIL_FUNC(8)
+DEFINE_XDP_TAIL_FUNC(9)
+DEFINE_XDP_TAIL_FUNC(10)
+DEFINE_XDP_TAIL_FUNC(11)
+DEFINE_XDP_TAIL_FUNC(12)
+DEFINE_XDP_TAIL_FUNC(13)
+DEFINE_XDP_TAIL_FUNC(14)
+DEFINE_XDP_TAIL_FUNC(15)
+DEFINE_XDP_TAIL_FUNC(16)
+DEFINE_XDP_TAIL_FUNC(17)
+DEFINE_XDP_TAIL_FUNC(18)
+DEFINE_XDP_TAIL_FUNC(19)
+DEFINE_XDP_TAIL_FUNC(20)
+DEFINE_XDP_TAIL_FUNC(21)
+DEFINE_XDP_TAIL_FUNC(22)
+DEFINE_XDP_TAIL_FUNC(23)
+DEFINE_XDP_TAIL_FUNC(24)
+DEFINE_XDP_TAIL_FUNC(25)
+DEFINE_XDP_TAIL_FUNC(26)
+DEFINE_XDP_TAIL_FUNC(27)
+DEFINE_XDP_TAIL_FUNC(28)
+DEFINE_XDP_TAIL_FUNC(29)
+DEFINE_XDP_TAIL_FUNC(30)
+DEFINE_XDP_TAIL_FUNC(31)
+DEFINE_XDP_TAIL_FUNC(32)
+DEFINE_XDP_TAIL_FUNC(33)
 
-bind_hook_t BindMonitor_Test_Caller;
-
-SEC("bind")
-bind_action_t
-BindMonitor_Test_Caller(bind_md_t* ctx)
+SEC("xdp")
+int
+xdp_test_caller(struct xdp_md* ctx)
 {
-    bpf_printk("BindMonitor_Test_Caller: Start Tail call\n");
-    if (bpf_tail_call(ctx, &bind_tail_call_map, 0) < 0) {
+    bpf_printk("xdp_test_caller: Starting Tail callees with [MAX COUNT = %d]\n", MAX_TAIL_CALL_COUNT);
+    if (bpf_tail_call(ctx, &xdp_tail_call_map, 0) < 0) {
         bpf_printk("Failed Tail call index %d\n", 0);
-        return BIND_DENY;
+        return -1;
     }
 
-    return BIND_DENY;
+    return -1;
 }
 
-SEC("bind/34")
-bind_action_t
-BindMonitor_Test_Callee34(bind_md_t* ctx)
+SEC("xdp/34")
+int
+xdp_test_callee34(struct xdp_md* ctx)
 {
-    bpf_printk("Last Tail call index: BindMonitor_Test_Callee34\n");
-    // This function is the last tail call function for the bind hook.
-    // This function returns BIND_PERMIT to allow the bind request to proceed.
-    return BIND_PERMIT;
+    bpf_printk("Last Tail call index: xdp_test_callee34. Returning success.\n");
+    // This function is the last tail call function for the xdp hook.
+    // This function returns 0 to allow the xdp request to proceed.
+    return 0;
 }

--- a/bpf/max_tail_call.c
+++ b/bpf/max_tail_call.c
@@ -5,6 +5,8 @@
 
 // Test to check the maximum tail call callee count, without the caller.
 
+#define MAX_TAIL_CALL_COUNT 32
+
 // Define a macro that defines a program which tail calls a function for the bind hook.
 #define DEFINE_BIND_TAIL_FUNC(x)                                                                \
     SEC("bind/" #x)                                                                             \
@@ -61,7 +63,7 @@ struct
 {
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
     __type(key, uint32_t);
-    __uint(max_entries, MAX_TAIL_CALL_CNT + 3);
+    __uint(max_entries, MAX_TAIL_CALL_COUNT + 3);
     __array(values, bind_action_t(bind_md_t* ctx));
 } bind_tail_call_map SEC(".maps") = {
     .values = {

--- a/bpf/max_tail_call.c
+++ b/bpf/max_tail_call.c
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL/MIT
 
 #include "bpf.h"
 
-// Test to check the maximum tail call callee count, without the caller.
+// Get performance numbers for the scaled maximum tail call callee count,
+// without the caller.
 
 #define MAX_TAIL_CALL_COUNT 32
 
 // Define a macro that defines a program which tail calls a function for the xdp hook.
-#define DEFINE_XDP_TAIL_FUNC(x)                                                         \
-    SEC("xdp/" #x)                                                                      \
-    int xdp_test_callee##x(struct xdp_md* ctx)                                          \
-    {                                                                                   \
-        int i = x + 1;                                                                  \
-        bpf_printk("xdp_test_callee: Tail call index [cur = %d], [next = %i]\n", x, i); \
-        bpf_tail_call(ctx, &xdp_tail_call_map, i);                                      \
-            bpf_printk("Tail call failed at index %d\n", i);                            \
-                                                                                        \
-        return -1;                                                                      \
+#define DEFINE_XDP_TAIL_FUNC(x)                          \
+    SEC("xdp/" #x)                                       \
+    int xdp_test_callee##x(struct xdp_md* ctx)           \
+    {                                                    \
+        int i = x + 1;                                   \
+        bpf_tail_call(ctx, &xdp_tail_call_map, i);       \
+        bpf_printk("Tail call failed at index %d\n", i); \
+                                                         \
+        return -1;                                       \
     }
 
 #define DECLARE_XDP_TAIL_FUNC(x) int xdp_test_callee##x(struct xdp_md* ctx);
@@ -117,7 +117,6 @@ SEC("xdp")
 int
 xdp_test_caller(struct xdp_md* ctx)
 {
-    bpf_printk("xdp_test_caller: Starting Tail callees with [MAX COUNT = %d]\n", MAX_TAIL_CALL_COUNT);
     bpf_tail_call(ctx, &xdp_tail_call_map, 0);
     bpf_printk("Failed Tail call index %d\n", 0);
     return -1;
@@ -127,7 +126,6 @@ SEC("xdp/34")
 int
 xdp_test_callee34(struct xdp_md* ctx)
 {
-    bpf_printk("Last Tail call index: xdp_test_callee34. Returning success.\n");
     // This function is the last tail call function for the xdp hook.
     // This function returns 0 to allow the xdp request to proceed.
     return 0;

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -398,4 +398,11 @@ tests:
     program_cpu_assignment:
       test_bpf_xdp_adjust_head_minus_100: all
 
+  - name: bpf_tail_callee_max
+    description: Tests the max tail call callees.
+    elf_file: max_tail_call.o
+    iteration_count: 1
+    program_cpu_assignment:
+      BindMonitor_Test_Caller: all
+
   # Add more test cases as needed

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -403,6 +403,6 @@ tests:
     elf_file: max_tail_call.o
     iteration_count: 1
     program_cpu_assignment:
-      BindMonitor_Test_Caller: all
+      xdp_test_caller: all
 
   # Add more test cases as needed

--- a/bpf/tests.yml
+++ b/bpf/tests.yml
@@ -401,7 +401,7 @@ tests:
   - name: bpf_tail_callee_max
     description: Tests the max tail call callees.
     elf_file: max_tail_call.o
-    iteration_count: 1
+    iteration_count: 1000000
     program_cpu_assignment:
       xdp_test_caller: all
 


### PR DESCRIPTION
I would like to commit the changes made in this PR.  Kind request for review.

Check the number of tail calls supported in Linux:
 - 33 MAX_TAIL_CALL_CNT : **32 Tail Calls + 1 Top-level Caller**
Or,
- 33 MAX_TAIL_CALL_CNT: **33 Tails Calls, excluding the Top-level Caller.**

----
**Test results:**
1.  **Performance numbers** show a significant difference between Linux and Windows platforms with MAX TAIL CALLS:
    **ebpf-for-windows:**
       - bpf_tail_callee_max,**120783,120361**
    **Linux:**
       - bpf_tail_callee_max,**287,294**

2. **MAXIMUM TAIL CALLS**: (without the Top-level caller)
   -  **Linux**: 33 Tail Callees supported 
   - **ebpf-for-windows**: 31 Tail Callees supported.
   
--
After removing bpf_printk in tail calls:

Windows (native): bpf_tail_callee_max,38388,38384
Linux: bpf_tail_callee_max,238,238